### PR TITLE
Add basic parsing error management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.8"
 gstreamer = "0.13"
 regex = "1.1"
 lazy_static = "1.3"
+failure = "0.1.5"
 
 [[example]]
 name = "dump"
@@ -38,4 +39,3 @@ structopt = "0.2"
 structopt-derive = "0.2"
 colored = "1.8"
 gnuplot = "0.0.31"
-failure = "0.1.5"

--- a/test-logs/corrupted-nocolor.log
+++ b/test-logs/corrupted-nocolor.log
@@ -1,0 +1,7 @@
+Hello world, I am here to fuzz
+0:00:00.007773544  8874 0x558951015c00 INFO                GST_INIT gst.c:510:init_pre: Initializing GStreamer Core Library version 1.10.4
+0:00:01.007927372  8874 0x558951015c00 DEBUG             GST_MEMORY gstallocator.c:592:_priv_gst_allocator_initialize: memory alignment: 7
+0:00:23.008032206  8874 0x558951015c00 TRACE        GST_REFCOUNTING gstobject.c:220:gst_object_init:<GstObject@0x55895101d040> 0x55895101d040 new
+0:01:10.008043265  8874 0x558951015c00 DEBUG             GST_MEMORY gstallocator.c:568:gst_allocator_sysmem_init: init allocator 0x55895101d040
+0:11:20.008067915  8874 0x558951015c00 TRACE        GST_REFCOUNTING gstobject.c:249:gst_object_ref:<allocatorsysmem0> 0x55895101d040 ref 1->2
+1:30:47.008078203  8874 0x558951015c00 DEBUG             GST_MEMORY gstallocator.c:210:gst_allocator_register: registering allocator 0x55895101d040 with name "SystemMemory"


### PR DESCRIPTION
Entry::new() now returns a Result<Entry, ParsingError> and no longer crashes
when it is unable to successfully parse a log line.

Fixes #5

I think this commit should be shipped in a 0.2.x release because it's an API break.