### PR TITLE
gitignore: stop ignoring test-logs/*.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.log
+!test-logs/*.log


### PR DESCRIPTION
These files are tracked test fixtures. Having them both committed and ignored causes release-plz to fail with a dirty working directory error.